### PR TITLE
Add text-to-speech functionality

### DIFF
--- a/src/components/result-audio.js
+++ b/src/components/result-audio.js
@@ -1,0 +1,53 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import textToSpeech from '../services/text-to-speech'
+
+const playButtonColor = '#1A478B'
+
+const Container = styled.div`
+  font-size: 20px;
+  flex: 1 0 30px;
+`
+
+const PlayButton = styled.a`
+  width: 20px;
+  height: 20px;
+  cursor: pointer;
+  display: inline-block;
+  border: 2px solid ${playButtonColor};
+  border-radius: 10px;
+`
+
+const PlayButtonArrow = styled.span`
+  width: 0;
+  height: 0;
+  margin-left: 6px;
+  margin-bottom: 4px;
+  display: inline-block;
+  border-top: 6px solid transparent;
+  border-bottom: 6px solid transparent;
+  border-left: 6px solid ${playButtonColor};
+`
+
+const ResultAudio = ({ title, lang }) => {
+  if (textToSpeech.isLanguageAvailable(lang)) {
+    const playAudio = () => textToSpeech.play({ text: title, lang: lang })
+    return (
+      <Container>
+        <PlayButton onClick={playAudio}><PlayButtonArrow /></PlayButton>
+      </Container>
+    )
+  }
+
+  return (
+    <Container />
+  )
+}
+
+ResultAudio.propTypes = {
+  title: PropTypes.string.isRequired,
+  lang: PropTypes.string.isRequired
+}
+
+export default ResultAudio

--- a/src/components/results.js
+++ b/src/components/results.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import ReactLoading from 'react-loading'
 import styled from 'styled-components'
 import ResultName from './result-name'
+import ResultAudio from './result-audio'
 import ResultLink from './result-link'
 
 const Container = styled.div`
@@ -20,8 +21,16 @@ const Names = styled.div`
   justify-content: space-between;
 `
 
-const Links = styled.div`
+const Audios = styled.div`
   padding-left: 32px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: space-between;
+`
+
+const Links = styled.div`
+  padding-left: 12px;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -70,6 +79,11 @@ const Results = ({ langLinks, loading }) => {
           validLinks.map(link => <ResultName key={link.url} lang={link.autonym} />)
         }
       </Names>
+      <Audios>
+        {
+          validLinks.map(link => <ResultAudio key={link.url} title={link.title} lang={link.lang} />)
+        }
+      </Audios>
       <Links>
         {
           validLinks.map(link => <ResultLink key={link.url} title={link.title} url={link.url} />)

--- a/src/services/text-to-speech.js
+++ b/src/services/text-to-speech.js
@@ -1,0 +1,43 @@
+const languageMappings = {
+  ca: 'ca-es',
+  zh: 'zh-cn',
+  da: 'da-dk',
+  nl: 'nl-nl',
+  en: 'en-gb',
+  fi: 'fi-fi',
+  fr: 'fr-fr',
+  de: 'de-de',
+  it: 'it-it',
+  ja: 'ja-jp',
+  ko: 'ko-kr',
+  nb: 'nb-no',
+  pl: 'pl-pl',
+  pt: 'pt-pt',
+  ru: 'ru-ru',
+  es: 'es-es',
+  sv: 'sv-se'
+}
+
+function isLanguageAvailable (lang) {
+  return !!languageMappings[lang]
+}
+
+function play ({ text, lang }) {
+  const params = {
+    key: 'ed10cf8e50fb44d99aa70d7d3061226f',
+    src: text,
+    hl: languageMappings[lang],
+    f: '16khz_16bit_stereo'
+  }
+
+  const query = Object.keys(params)
+    .map(key => `${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`)
+    .join('&')
+
+  new Audio(`https://api.voicerss.org/?${query}`).play()
+}
+
+export default {
+  isLanguageAvailable,
+  play
+}


### PR DESCRIPTION
Simple button to listen to how the term is pronounced in the respective language.

It uses http://www.voicerss.org/ which is free (just requires an API key).

BTW: After executing `npm install` on my Linux system, about 80% of all lines of `package-lock.json` have been modified (basically each entry in the JSON, also `fsevents` gets removed from the file completely). My npm version is 5.3.0 which comes with the latest node.js 8.2.1. Seems that the new npm still is unusable for cross-platform version locking. Luckily, for this PR I didn't have to add any modules, so I reverted the file before commiting.